### PR TITLE
chore(pyproject): remove deprecated license classifier

### DIFF
--- a/python/{{ cookiecutter.dash_name }}/pyproject.toml
+++ b/python/{{ cookiecutter.dash_name }}/pyproject.toml
@@ -13,7 +13,6 @@ authors = [
 ]
 requires-python = ">=3.X"
 classifiers = [
-    "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.13",
 ]


### PR DESCRIPTION
These were deprecated in [PEP 639](https://peps.python.org/pep-0639/#deprecate-license-classifiers)

Committed via https://github.com/asottile/all-repos